### PR TITLE
Avoid overlapping image when drawing to the canvas

### DIFF
--- a/bicubicInterpolation.js
+++ b/bicubicInterpolation.js
@@ -15,39 +15,38 @@ $.fn.bicubicImgInterpolation = function(settings) {
 			drawCanvas(can, imgW*6, imgH*6, src, callback, this, settings.crossOrigin);
 		}
 	});
-    
+
 	function drawCanvas(can, imgW, imgH, src, callback, imgEl, crossOrigin) {
-	
+
 		var ctx = can.getContext('2d');
 		var img = new Image();
 		if(crossOrigin) {
 		    img.setAttribute('crossOrigin', 'anonymous'); //tainted canvases may not be exported chrome, ie will also throw security error
 		}
-		
+
 		var w = imgW;
 		var h = imgH;
 
 		img.onload = function() {
-			
+
 			// Step it down several times
 			var can2 = document.createElement('canvas');
 			can2.width = w;
 			can2.height = h;
 			var ctx2 = can2.getContext('2d');
-			
-			// Draw it at 1/2 size 3 times (step down three times)
+
+			// Draw it at 1/2 size 3 times (step down three times), making sure we don't overlap it
 			ctx2.drawImage(img, 0, 0, w/2, h/2);
-			ctx2.drawImage(can2, 0, 0, w/2, h/2, 0, 0, w/4, h/4);
-			ctx2.drawImage(can2, 0, 0, w/4, h/4, 0, 0, w/6, h/6);
-			ctx.drawImage(can2, 0, 0, w/6, h/6, 0, 0, w/6, h/6);
+			ctx2.drawImage(can2, 0, 0, w/2, h/2, w/2, h/2, w/4, h/4);
+			ctx.drawImage(can2, w/2, h/2, w/4, h/4, 0, 0, w/6, h/6);
 			if(callback) {
 				callback(can, this.src, imgEl);
 			}
 		};
-	
+
 		img.src = src;
 	};
-	
+
 	function drawHighResolutionImgThumbnail(can, attrSrc, imgEl) {
 		$(imgEl).attr('src', can.toDataURL("image/png"));
 		$(imgEl).attr('data-src', attrSrc);


### PR DESCRIPTION
Thank you for this plugin!  I noticed the pixelation was a lot better but there was some overlap in the temporary image yielding a jumbled output.  This PR ensures that does not happen by always drawing to a blank area of the canvas.

![image](https://cloud.githubusercontent.com/assets/64349/15624453/15165f72-2456-11e6-9451-8d09bee19139.png)
